### PR TITLE
add entry type matcher for debit or credit entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ match:
     min: <integer>
     max: <integer>
     value: <integer>       # Either min AND max OR value is used
-  debit: <object>          # Include this to only match on debits
   individualName: <string> # Compare the IndividualName on EntryDetail records
   routingNumber: <string>  # Exact match of ABA routing number (RDFIIdentification and CheckDigit)
   traceNumber: <string>    # Exact match of TraceNumber
-
+  type: <string>       # credit, debit or empty string to skip the type match
 action:
   # Copy the EntryDetail to another directory
   copy:
@@ -101,7 +100,7 @@ action:
 
 ```
   - match:
-      debit: {} # remove if you want to return Credits and Debits
+      type: debit
       amount:
         min: 100000 # $1,000
         min: 120000 # $1,200

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ match:
   individualName: <string> # Compare the IndividualName on EntryDetail records
   routingNumber: <string>  # Exact match of ABA routing number (RDFIIdentification and CheckDigit)
   traceNumber: <string>    # Exact match of TraceNumber
-  type: <string>       # credit, debit or empty string to skip the type match
+  entryType: <string>      # Check TransactionCode of entry if it's credit or debit. Accepted values: credit, debit or empty to skip the type match
 action:
   # Copy the EntryDetail to another directory
   copy:
@@ -100,7 +100,7 @@ action:
 
 ```
   - match:
-      type: debit
+      entryType: debit
       amount:
         min: 100000 # $1,000
         min: 120000 # $1,200

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.15
 require (
 	github.com/markbates/pkger v0.17.1
 	github.com/moov-io/ach v1.6.3
-	github.com/moov-io/base v0.17.0
+	github.com/moov-io/base v0.18.0
 	github.com/stretchr/testify v1.7.0
 	goftp.io/server v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-migrate/migrate/v4 v4.13.0/go.mod h1:RUEXGkgYXTOdBY9Rbs9izc/SOalUK+dDi7YphFV/CUI=
 github.com/golang-migrate/migrate/v4 v4.14.1 h1:qmRd/rNGjM1r3Ve5gHd5ZplytrD02UcItYNxJ3iUHHE=
 github.com/golang-migrate/migrate/v4 v4.14.1/go.mod h1:l7Ks0Au6fYHuUIxUhQ0rcVX1uLlJg54C/VvW7tvxSz0=
@@ -227,6 +228,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -343,6 +345,7 @@ github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3t
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -411,6 +414,8 @@ github.com/moov-io/ach v1.6.3/go.mod h1:OkWC8pGJm8kNeGWF6MErnbBbjmJZm7qRjx5/bseQ
 github.com/moov-io/base v0.15.4/go.mod h1:oZd7yveRERNu1kGgW9KAevUNlz45Qfc9Slax3vWR544=
 github.com/moov-io/base v0.17.0 h1:8SQmQXYEJgnQHAead1tZcgUWNBv/ZveonXQ22T2wUlk=
 github.com/moov-io/base v0.17.0/go.mod h1:ShJrBLiHy1yfK+/34bq9eteAAs5VvAgdDbRuPjsOxLo=
+github.com/moov-io/base v0.18.0 h1:N9c6HCX8I/z4w84EMkPGzclCsJ+MTYBfwm3pzVe2VKo=
+github.com/moov-io/base v0.18.0/go.mod h1:jYP2X0g/Q3Qs3JMXE6NSaz74z1bNgOKAd64p9Q38JN4=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mutecomm/go-sqlcipher/v4 v4.4.0/go.mod h1:PyN04SaWalavxRGH9E8ZftG6Ju7rsPrGmQRjrEaVpiY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -480,6 +485,7 @@ github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
 github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
+github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -496,6 +502,7 @@ github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB8
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -504,6 +511,7 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -578,6 +586,7 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -687,6 +696,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201029221708-28c70e62bb1d h1:dOiJ2n2cMwGLce/74I/QHMbnpk5GfY7InR8rczoMqRM=
 golang.org/x/net v0.0.0-20201029221708-28c70e62bb1d/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -704,6 +714,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -758,6 +770,8 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -817,12 +831,14 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200806022845-90696ccdc692/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200814230902-9882f1d1823d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200817023811-d00afeaade8f/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200818005847-188abfa75333/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/response/matcher.go
+++ b/pkg/response/matcher.go
@@ -82,12 +82,12 @@ func (m Matcher) FindAction(ed *ach.EntryDetail) *service.Action {
 		}
 
 		// Check if this Entry is a debit
-		if matcher.Debit != nil {
-			if matchedDebit(matcher, ed) {
-				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d debit positive match", ed.TransactionCode))
+		if matcher.Type != service.TypeEmpty {
+			if matchedType(matcher, ed) {
+				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d type positive match", ed.TransactionCode))
 				positive++
 			} else {
-				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d debit negative match", ed.TransactionCode))
+				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d type negative match", ed.TransactionCode))
 				negative++
 			}
 		}
@@ -136,6 +136,17 @@ func matchedAmount(m service.Match, ed *ach.EntryDetail) bool {
 	return inner
 }
 
+func matchedType(m service.Match, ed *ach.EntryDetail) bool {
+	switch {
+	case m.Type == service.TypeDebit && matchedDebit(m, ed):
+		return true
+	case m.Type == service.TypeCredit && !matchedDebit(m, ed):
+		return true
+	default:
+		return false
+	}
+}
+
 func matchedDebit(m service.Match, ed *ach.EntryDetail) bool {
 	switch ed.TransactionCode {
 	case ach.CheckingDebit, ach.SavingsDebit, ach.GLDebit, ach.LoanDebit:
@@ -149,7 +160,6 @@ func matchedIndividualName(m service.Match, ed *ach.EntryDetail) bool {
 }
 
 func (m Matcher) debugLog(msg string) {
-	if m.Debug {
-		m.Logger.Info().Log(msg)
-	}
+	fmt.Println(msg)
+	// m.Logger.Info().Log(msg)
 }

--- a/pkg/response/matcher.go
+++ b/pkg/response/matcher.go
@@ -82,7 +82,7 @@ func (m Matcher) FindAction(ed *ach.EntryDetail) *service.Action {
 		}
 
 		// Check if this Entry is a debit
-		if matcher.Type != service.TypeEmpty {
+		if matcher.EntryType != service.EntryTypeEmpty {
 			if matchedType(matcher, ed) {
 				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d type positive match", ed.TransactionCode))
 				positive++
@@ -138,9 +138,9 @@ func matchedAmount(m service.Match, ed *ach.EntryDetail) bool {
 
 func matchedType(m service.Match, ed *ach.EntryDetail) bool {
 	switch {
-	case m.Type == service.TypeDebit && matchedDebit(m, ed):
+	case m.EntryType == service.EntryTypeDebit && matchedDebit(m, ed):
 		return true
-	case m.Type == service.TypeCredit && !matchedDebit(m, ed):
+	case m.EntryType == service.EntryTypeCredit && !matchedDebit(m, ed):
 		return true
 	default:
 		return false

--- a/pkg/response/matcher.go
+++ b/pkg/response/matcher.go
@@ -83,7 +83,7 @@ func (m Matcher) FindAction(ed *ach.EntryDetail) *service.Action {
 
 		// Check if this Entry is a debit
 		if matcher.EntryType != service.EntryTypeEmpty {
-			if matchedType(matcher, ed) {
+			if matchedEntryType(matcher, ed) {
 				m.debugLog(fmt.Sprintf("EntryDetail.TransactionCode=%d type positive match", ed.TransactionCode))
 				positive++
 			} else {
@@ -136,7 +136,7 @@ func matchedAmount(m service.Match, ed *ach.EntryDetail) bool {
 	return inner
 }
 
-func matchedType(m service.Match, ed *ach.EntryDetail) bool {
+func matchedEntryType(m service.Match, ed *ach.EntryDetail) bool {
 	switch {
 	case m.EntryType == service.EntryTypeDebit && matchedDebit(m, ed):
 		return true
@@ -160,6 +160,7 @@ func matchedIndividualName(m service.Match, ed *ach.EntryDetail) bool {
 }
 
 func (m Matcher) debugLog(msg string) {
-	fmt.Println(msg)
-	// m.Logger.Info().Log(msg)
+	if m.Debug {
+		m.Logger.Info().Log(msg)
+	}
 }

--- a/pkg/response/matcher_test.go
+++ b/pkg/response/matcher_test.go
@@ -32,17 +32,17 @@ func TestMatchType(t *testing.T) {
 	}
 
 	tests := []test{
-		{input: ach.CheckingDebit, entryType: service.TypeDebit, want: true},
-		{input: ach.SavingsDebit, entryType: service.TypeDebit, want: true},
-		{input: ach.CheckingCredit, entryType: service.TypeCredit, want: true},
-		{input: ach.CheckingDebit, entryType: service.TypeCredit, want: false},
-		{input: ach.SavingsDebit, entryType: service.TypeCredit, want: false},
-		{input: ach.CheckingCredit, entryType: service.TypeDebit, want: false},
+		{input: ach.CheckingDebit, entryType: service.EntryTypeDebit, want: true},
+		{input: ach.SavingsDebit, entryType: service.EntryTypeDebit, want: true},
+		{input: ach.CheckingCredit, entryType: service.EntryTypeCredit, want: true},
+		{input: ach.CheckingDebit, entryType: service.EntryTypeCredit, want: false},
+		{input: ach.SavingsDebit, entryType: service.EntryTypeCredit, want: false},
+		{input: ach.CheckingCredit, entryType: service.EntryTypeDebit, want: false},
 	}
 
 	for _, tc := range tests {
 		m := service.Match{
-			Type: tc.entryType,
+			EntryType: tc.entryType,
 		}
 		ed := ach.NewEntryDetail()
 		ed.TransactionCode = tc.input
@@ -96,7 +96,7 @@ func TestMultiMatch(t *testing.T) {
 						Min: 500000,  // $5,000.00
 						Max: 1000000, // $10,000.00
 					},
-					Type: service.TypeDebit,
+					EntryType: service.EntryTypeDebit,
 				},
 				Action: service.Action{
 					Return: &service.Return{

--- a/pkg/response/matcher_test.go
+++ b/pkg/response/matcher_test.go
@@ -24,7 +24,7 @@ func TestMatchAccountNumber(t *testing.T) {
 	require.False(t, matchesAccountNumber(m, ed))
 }
 
-func TestMatchType(t *testing.T) {
+func TestMatchEntryType(t *testing.T) {
 	type test struct {
 		input     int
 		entryType service.EntryType
@@ -47,7 +47,7 @@ func TestMatchType(t *testing.T) {
 		ed := ach.NewEntryDetail()
 		ed.TransactionCode = tc.input
 
-		require.Equal(t, tc.want, matchedType(m, ed))
+		require.Equal(t, tc.want, matchedEntryType(m, ed))
 	}
 }
 

--- a/pkg/response/matcher_test.go
+++ b/pkg/response/matcher_test.go
@@ -24,25 +24,30 @@ func TestMatchAccountNumber(t *testing.T) {
 	require.False(t, matchesAccountNumber(m, ed))
 }
 
-func TestMatchDebit(t *testing.T) {
-	m := service.Match{
-		Debit: &service.Debit{},
-	}
-	ed := ach.NewEntryDetail()
-
-	tests := []int{ach.CheckingDebit, ach.SavingsDebit}
-	for i := range tests {
-		ed.TransactionCode = tests[i]
-
-		require.True(t, matchedDebit(m, ed))
+func TestMatchType(t *testing.T) {
+	type test struct {
+		input     int
+		entryType service.EntryType
+		want      bool
 	}
 
-	// negative matches
-	tests = []int{ach.CheckingCredit, ach.SavingsCredit}
-	for i := range tests {
-		ed.TransactionCode = tests[i]
+	tests := []test{
+		{input: ach.CheckingDebit, entryType: service.TypeDebit, want: true},
+		{input: ach.SavingsDebit, entryType: service.TypeDebit, want: true},
+		{input: ach.CheckingCredit, entryType: service.TypeCredit, want: true},
+		{input: ach.CheckingDebit, entryType: service.TypeCredit, want: false},
+		{input: ach.SavingsDebit, entryType: service.TypeCredit, want: false},
+		{input: ach.CheckingCredit, entryType: service.TypeDebit, want: false},
+	}
 
-		require.False(t, matchedDebit(m, ed))
+	for _, tc := range tests {
+		m := service.Match{
+			Type: tc.entryType,
+		}
+		ed := ach.NewEntryDetail()
+		ed.TransactionCode = tc.input
+
+		require.Equal(t, tc.want, matchedType(m, ed))
 	}
 }
 
@@ -76,6 +81,12 @@ func TestMatchTraceNumber(t *testing.T) {
 	require.False(t, matchesTraceNumber(m, ed))
 }
 
+// Following data is used for TestMultiMatch
+// TransactionCode  RDFIIdentification  AccountNumber      Amount  Name                    TraceNumber      Category
+// 37               22147578            221475786          100     John Doe                273976367520468
+
+// TransactionCode  RDFIIdentification  AccountNumber      Amount  Name                    TraceNumber      Category
+// 22               27397636            273976369          100     Incorrect Name          273976367520469
 func TestMultiMatch(t *testing.T) {
 	matcher := Matcher{
 		Responses: []service.Response{
@@ -85,7 +96,7 @@ func TestMultiMatch(t *testing.T) {
 						Min: 500000,  // $5,000.00
 						Max: 1000000, // $10,000.00
 					},
-					Debit: &service.Debit{},
+					Type: service.TypeDebit,
 				},
 				Action: service.Action{
 					Return: &service.Return{

--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -70,7 +70,7 @@ type Response struct {
 type Match struct {
 	AccountNumber  string
 	Amount         *Amount
-	Type           EntryType
+	EntryType      EntryType
 	IndividualName string
 	RoutingNumber  string
 	TraceNumber    string
@@ -85,9 +85,9 @@ type Amount struct {
 type EntryType string
 
 const (
-	TypeEmpty  EntryType = ""
-	TypeDebit  EntryType = "debit"
-	TypeCredit EntryType = "credit"
+	EntryTypeEmpty  EntryType = ""
+	EntryTypeDebit  EntryType = "debit"
+	EntryTypeCredit EntryType = "credit"
 )
 
 type Action struct {

--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -70,7 +70,7 @@ type Response struct {
 type Match struct {
 	AccountNumber  string
 	Amount         *Amount
-	Debit          *Debit
+	Type           EntryType
 	IndividualName string
 	RoutingNumber  string
 	TraceNumber    string
@@ -82,7 +82,13 @@ type Amount struct {
 	Max   int
 }
 
-type Debit struct{}
+type EntryType string
+
+const (
+	TypeEmpty  EntryType = ""
+	TypeDebit  EntryType = "debit"
+	TypeCredit EntryType = "credit"
+)
 
 type Action struct {
 	Copy       *Copy


### PR DESCRIPTION
I want to test the return of `credit` transfer. Currently you can add matcher only for `debit`. With this PR we can specify type on the entry in a matcher.

```yaml
  - match:
      entryType: credit
      amount:
        min: 100000 # $1,000
        min: 120000 # $1,200
    action:
      return:
        code: "R01"
```