### PR TITLE
Allow setting ValidateOpts in config.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
       run: make dev-docker
 
     - name: Docker Push
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && github.repository == 'moov-io'
       run: |+
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           make dev-push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) and us
 You can pull a working repository of our code code with git:
 
 ```
-$ midir -p $GOPATH/src/github.com/moov-io/
+$ mkdir -p $GOPATH/src/github.com/moov-io/
 $ cd $GOPATH/src/github.com/moov-io/
 $ git clone git@github.com:moov-io/ach-test-harness.git
 ```
@@ -43,7 +43,7 @@ We recommend using additional git remote's for pushing/pulling code. This allows
 First, [Fork our project](https://github.com/moov-io/ach-test-harness) somewhere and after that's done add the remote:
 
 ```
-$ cd $GOPATH/src/github.com/moov-io/ach-test-harness # Whereever this project's source code is
+$ cd $GOPATH/src/github.com/moov-io/ach-test-harness # Wherever this project's source code is
 
 $ git remote add $user git@github.com:$user/ach-test-harness.git # After
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: false
+  ValidateOpts: # can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
   Responses:
     # Entries that match both the DFIAccountNumber and TraceNumber will be returned with a R03 return code.
     - match:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: false
-  ValidateOpts: # can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
+  # ValidateOpts can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
+  ValidateOpts: {}
   Responses:
     # Entries that match both the DFIAccountNumber and TraceNumber will be returned with a R03 return code.
     - match:

--- a/cmd/ach-test-harness/main.go
+++ b/cmd/ach-test-harness/main.go
@@ -13,7 +13,9 @@ import (
 
 func main() {
 	env := &service.Environment{
-		Logger: log.NewDefaultLogger().Set("app", log.String("ach-test-harness")).Set("version", log.String(achtestharness.Version)),
+		Logger: log.NewDefaultLogger().
+			Set("app", log.String("ach-test-harness")).
+			Set("version", log.String(achtestharness.Version)),
 	}
 
 	env, err := service.NewEnvironment(env)
@@ -31,7 +33,7 @@ func main() {
 	// Initialize our responders
 	fileWriter := response.NewFileWriter(env.Logger, env.Config.Servers, env.FTPServer)
 	fileTransformer := response.NewFileTransformer(env.Logger, env.Config, env.Config.Responses, fileWriter)
-	response.Register(env.Logger, env.FTPServer, fileTransformer)
+	response.Register(env.Logger, env.Config.ValidateOpts, env.FTPServer, fileTransformer)
 
 	// Block for a signal to shutdown
 	service.AwaitTermination(env.Logger, termListener)

--- a/configs/config.default.yml
+++ b/configs/config.default.yml
@@ -18,4 +18,5 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: false
+  ValidateOpts:
   Responses: []

--- a/configs/config.default.yml
+++ b/configs/config.default.yml
@@ -18,5 +18,5 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: false
-  ValidateOpts:
+  ValidateOpts: {}
   Responses: []

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -18,6 +18,7 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: true
+  ValidateOpts: # can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
   Responses:
   - match:
       # This matches ./examples/utility-bill.ach

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -18,7 +18,8 @@ ACHTestHarness:
         Address: ":3333"
   Matching:
     Debug: true
-  ValidateOpts: # can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
+  # ValidateOpts can use all values from https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts
+  ValidateOpts: {}
   Responses:
   - match:
       # This matches ./examples/utility-bill.ach

--- a/pkg/response/file_transformer.go
+++ b/pkg/response/file_transformer.go
@@ -15,7 +15,7 @@ type FileTransfomer struct {
 	Matcher      Matcher
 	Entry        EntryTransformers
 	Writer       FileWriter
-	ValidateOpts ach.ValidateOpts
+	ValidateOpts *ach.ValidateOpts
 
 	returnPath string
 }
@@ -38,10 +38,10 @@ func NewFileTransformer(logger log.Logger, cfg *service.Config, responses []serv
 
 func (ft *FileTransfomer) Transform(file *ach.File) error {
 	out := ach.NewFile()
-	out.SetValidation(&ft.ValidateOpts)
+	out.SetValidation(ft.ValidateOpts)
 
 	out.Header = ach.NewFileHeader()
-	out.Header.SetValidation(&ft.ValidateOpts)
+	out.Header.SetValidation(ft.ValidateOpts)
 
 	out.Header.ImmediateDestination = file.Header.ImmediateOrigin
 	out.Header.ImmediateDestinationName = file.Header.ImmediateOriginName

--- a/pkg/response/file_transformer.go
+++ b/pkg/response/file_transformer.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FileTransfomer struct {
-	Matcher Matcher
-	Entry   EntryTransformers
-	Writer  FileWriter
+	Matcher      Matcher
+	Entry        EntryTransformers
+	Writer       FileWriter
+	ValidateOpts ach.ValidateOpts
 
 	returnPath string
 }
@@ -26,7 +27,8 @@ func NewFileTransformer(logger log.Logger, cfg *service.Config, responses []serv
 			&CorrectionTransformer{},
 			&ReturnTransformer{},
 		}),
-		Writer: writer,
+		Writer:       writer,
+		ValidateOpts: cfg.ValidateOpts,
 	}
 	if cfg.Servers.FTP != nil {
 		xform.returnPath = cfg.Servers.FTP.Paths.Return
@@ -36,8 +38,11 @@ func NewFileTransformer(logger log.Logger, cfg *service.Config, responses []serv
 
 func (ft *FileTransfomer) Transform(file *ach.File) error {
 	out := ach.NewFile()
+	out.SetValidation(&ft.ValidateOpts)
 
 	out.Header = ach.NewFileHeader()
+	out.Header.SetValidation(&ft.ValidateOpts)
+
 	out.Header.ImmediateDestination = file.Header.ImmediateOrigin
 	out.Header.ImmediateDestinationName = file.Header.ImmediateOriginName
 	out.Header.ImmediateOrigin = file.Header.ImmediateDestination

--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -15,7 +15,7 @@ type GlobalConfig struct {
 // Config defines all the configuration for the app
 type Config struct {
 	Servers      ServerConfig
-	ValidateOpts ach.ValidateOpts
+	ValidateOpts *ach.ValidateOpts
 	Matching     Matching
 	Responses    []Response
 }

--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -14,9 +14,10 @@ type GlobalConfig struct {
 
 // Config defines all the configuration for the app
 type Config struct {
-	Servers   ServerConfig
-	Matching  Matching
-	Responses []Response
+	Servers      ServerConfig
+	ValidateOpts ach.ValidateOpts
+	Matching     Matching
+	Responses    []Response
 }
 
 // ServerConfig - Groups all the http configs for the servers and ports that get opened.


### PR DESCRIPTION
# Changes
Add `ValidateOpts` object in config to leverage custom validation from ACH module https://pkg.go.dev/github.com/moov-io/ach#ValidateOpts

# Why Are Changes Being Made
To allow custom validation so 10 digits `ImmediateOrigin` and other unusual use cases do not make the ACH return generation fail.
Nacha specs on `ImmediateOrigin` allowing 10 digits : https://help.imscre.net/hc/en-us/articles/360000402343-NACHA-Setup
Fixes https://github.com/moov-io/ach-test-harness/issues/35

@adamdecaf 
Could you review ? Please do not hesitate to ask me for any changes, this is my first time working with Golang and I do not know the convention/style.