### PR TITLE
response: write parent directories if needed

### DIFF
--- a/pkg/response/file_writer_test.go
+++ b/pkg/response/file_writer_test.go
@@ -1,0 +1,35 @@
+package response
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"goftp.io/server/driver/file"
+)
+
+func TestFileWriter__mkdir(t *testing.T) {
+	dir := t.TempDir()
+	factory := &file.DriverFactory{
+		RootPath: dir,
+	}
+	driver, err := factory.NewDriver()
+	require.NoError(t, err)
+
+	path := filepath.Join("foo", "Bar", "baz", "example.ach")
+
+	err = mkdir(driver, path)
+	require.NoError(t, err)
+
+	// Check that the directory exists
+	fd, err := os.Stat(filepath.Join(dir, filepath.Dir(path)))
+	require.NoError(t, err)
+	require.True(t, fd.IsDir())
+
+	// Check the file does not exist
+	fd, err = os.Stat(filepath.Join(dir, path))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+	require.Nil(t, fd)
+}


### PR DESCRIPTION
An error will be raised If `./reconciliation/` does not exist and a matcher attempts to write within the directory. This fixes that.