### PR TITLE
entries: search even partial files

### DIFF
--- a/pkg/entries/repository_entry.go
+++ b/pkg/entries/repository_entry.go
@@ -59,9 +59,9 @@ func (r *ftpRepository) Search(opts SearchOptions) ([]*ach.EntryDetail, error) {
 }
 
 func filterEntries(path string, opts SearchOptions) ([]*ach.EntryDetail, error) {
-	file, err := ach.ReadFile(path)
-	if file == nil || err != nil {
-		return nil, fmt.Errorf("reading ACH file %s: %v", path, err)
+	file, _ := ach.ReadFile(path)
+	if file == nil {
+		return nil, nil
 	}
 
 	tooOld, err := opts.fileTooOld(file)

--- a/pkg/entries/repository_entry_test.go
+++ b/pkg/entries/repository_entry_test.go
@@ -40,3 +40,11 @@ func TestRepository(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 }
+
+func TestRepository__filterEntries(t *testing.T) {
+	var opts SearchOptions
+
+	entries, err := filterEntries("/tmp/noexist/foobar", opts)
+	require.NoError(t, err)
+	require.Len(t, entries, 0)
+}


### PR DESCRIPTION
Often files could be partially written or incomplete from reconciliation efforts. These partial files can trip up entry search when they really don't need to. If we're able to perform a partial search within a file then let's try. 