### PR TITLE
Optimize debug logs

### DIFF
--- a/pkg/response/match/matcher.go
+++ b/pkg/response/match/matcher.go
@@ -58,18 +58,18 @@ func (m Matcher) FindAction(ed *ach.EntryDetail) (copyAction *service.Action, pr
 
 		if m.Debug {
 			logger = logger.With(log.Fields{
-				"response_idx":         log.Int(i),
-				"account_number":       log.String(matcher.AccountNumber),
-				"entry_type":           log.String(string(matcher.EntryType)),
-				"individual_name":      log.String(matcher.IndividualName),
-				"routing_number":       log.String(matcher.RoutingNumber),
-				"matcher_trace_number": log.String(matcher.TraceNumber),
-				"ed.account_number":    log.String(ed.DFIAccountNumber),
-				"ed.entry_type":        log.String(fmt.Sprintf("%d", ed.TransactionCode)),
-				"ed.individual_name":   log.String(ed.IndividualName),
-				"ed.routing_number":    log.String(ed.RDFIIdentification + ed.CheckDigit),
-				"ed.trace_number":      log.String(ed.TraceNumber),
-				"ed.amount":            log.String(fmt.Sprintf("%d", ed.Amount)),
+				"matcher.response_idx":    log.Int(i),
+				"matcher.account_number":  log.String(matcher.AccountNumber),
+				"matcher.entry_type":      log.String(string(matcher.EntryType)),
+				"matcher.individual_name": log.String(matcher.IndividualName),
+				"matcher.routing_number":  log.String(matcher.RoutingNumber),
+				"matcher.trace_number":    log.String(matcher.TraceNumber),
+				"ed.account_number":       log.String(ed.DFIAccountNumber),
+				"ed.entry_type":           log.String(fmt.Sprintf("%d", ed.TransactionCode)),
+				"ed.individual_name":      log.String(ed.IndividualName),
+				"ed.routing_number":       log.String(ed.RDFIIdentification + ed.CheckDigit),
+				"ed.trace_number":         log.String(ed.TraceNumber),
+				"ed.amount":               log.String(fmt.Sprintf("%d", ed.Amount)),
 			})
 		}
 
@@ -138,13 +138,22 @@ func (m Matcher) FindAction(ed *ach.EntryDetail) (copyAction *service.Action, pr
 			}
 		}
 
-		// Return the Action if we've still matched
-		logger.Logf(
-			"FINAL matching score negative=%d (%s) positive=%d (%s)",
-			negative, strings.Join(negativeMatchers, ", "),
-			positive, strings.Join(positiveMatchers, ", "),
-		)
+		// format the list of negative and positive matchers for logging
+		var b strings.Builder
 
+		b.WriteString(fmt.Sprintf("FINAL matching score negative=%d", negative))
+		if len(negativeMatchers) > 0 {
+			b.WriteString(fmt.Sprintf(" (%s)", strings.Join(negativeMatchers, ", ")))
+		}
+
+		b.WriteString(fmt.Sprintf(" positive=%d", positive))
+		if len(positiveMatchers) > 0 {
+			b.WriteString(fmt.Sprintf(" (%s)", strings.Join(positiveMatchers, ", ")))
+		}
+
+		logger.Log(b.String())
+
+		// Return the Action if we've still matched
 		if negative == 0 && positive > 0 {
 			// Action is valid, figure out where it belongs
 			if m.Responses[i].Action.Copy != nil {

--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -116,7 +116,7 @@ func (m Match) Context() map[string]log.Valuer {
 
 	if m.Amount != nil {
 		var amount = m.Amount.Value
-		logFields["amount"] = log.Int(amount)
+		logFields["matcher.amount"] = log.Int(amount)
 	}
 
 	return logFields


### PR DESCRIPTION
# Changes
* add entry details to the log context
* output matching results in a single entry

# Why Are Changes Being Made

* Due to massive number of log entries and lack of information about entry details it was hard to understand which rule matched.

Now log entry looks like this:
```shell
platform-dev-ach-test-harness-1  | ts=2024-02-02T20:26:29Z msg="starting EntryDetail matching" app=ach-test-harness entry_trace_number=291471029446126 level=info version=v0.
9.1
platform-dev-ach-test-harness-1  | ts=2024-02-02T20:26:29Z msg="FINAL matching score negative=0 positive=4 (DFIAccountNumber, RDFIIdentification, Amount, TransactionCode)" a
pp=ach-test-harness copy_path=/reconciliation/ ed.account_number=55555 ed.amount=10000 ed.entry_type=22 ed.individual_name="Moov Financial        " ed.routing_number=2739701
16 ed.trace_number=291471029446126 entry_trace_number=291471029446126 level=info matcher.account_number=55555 matcher.amount=10000 matcher.entry_type=credit matcher.individual_name= matcher.response_idx=11 matcher.routing_number=273970116 matcher.trace_number= version=v0.9.1
```

before it was:

```
platform-dev-ach-test-harness-1  | ts=2024-02-02T19:50:15Z msg="starting EntryDetail matching" app=ach-test-harness entry_trace_number=291471029029390 level=info version=v0.
9.1
platform-dev-ach-test-harness-1  | ts=2024-02-02T19:50:15Z msg="RDFIIdentification negative match" account_number= amount=551 app=ach-test-harness ed.account_number=55555 ed
.amount=10000 ed.entry_type=22 ed.routing_number=273970116 entry_trace_number=291471029029390 entry_type=credit individual_name= level=info matcher_trace_number= response_id
x=5 return_code=R02 routing_number=221475786 version=v0.9.1
platform-dev-ach-test-harness-1  | ts=2024-02-02T19:50:15Z msg="Amount negative match" account_number= amount=551 app=ach-test-harness ed.account_number=55555 ed.amount=1000
0 ed.entry_type=22 ed.routing_number=273970116 entry_trace_number=291471029029390 entry_type=credit individual_name= level=info matcher_trace_number= response_idx=5 return_c
ode=R02 routing_number=221475786 version=v0.9.1
platform-dev-ach-test-harness-1  | ts=2024-02-02T19:50:15Z msg="TransactionCode type positive match" account_number= amount=551 app=ach-test-harness ed.account_number=55555
ed.amount=10000 ed.entry_type=22 ed.routing_number=273970116 entry_trace_number=291471029029390 entry_type=credit individual_name= level=info matcher_trace_number= response_
idx=5 return_code=R02 routing_number=221475786 version=v0.9.1
platform-dev-ach-test-harness-1  | ts=2024-02-02T19:50:15Z msg="FINAL matching score negative=2 positive=1" account_number= amount=551 app=ach-test-harness ed.account_number
=55555 ed.amount=10000 ed.entry_type=22 ed.routing_number=273970116 entry_trace_number=291471029029390 entry_type=credit individual_name= level=info matcher_trace_number= re
sponse_idx=5 return_code=R02 routing_number=221475786 version=v0.9.1
```

