### PR TITLE
response/match: add "NOT" matcher conditions

### DIFF
--- a/pkg/service/model_config.go
+++ b/pkg/service/model_config.go
@@ -95,6 +95,7 @@ type Matching struct {
 
 type Response struct {
 	Match  Match
+	Not    Match
 	Action Action
 }
 


### PR DESCRIPTION
These are designed to work where, when populated, will act to exclude actions from running against entries.

For example, if you wanted to return every entry of a certain amount except for those of a certain CompanyIdentification you'd specify the following matcher.

```yaml
match:
  amount: 1234
not:
  companyIdentification: "YourOrg"
action:
  return:
    code: "R01"
```
