### PR TITLE
Add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,16 @@
+# Use https://app.stepsecurity.io/ to improve workflow security
+name: zizmor
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: moov-io/.github/.github/workflows/zizmor.yml@768836368a4ebdf0959c6497d41433e7193103cc

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,15 @@ module github.com/moov-io/ach-test-harness
 
 go 1.25.8
 
-toolchain go1.26.6
+toolchain go1.26.5
 
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/gorilla/mux v1.8.1
 	github.com/markbates/pkger v0.17.1
 	github.com/moov-io/ach v1.63.3
-	github.com/moov-io/base v0.63.2
-	github.com/stretchr/testify v1.12.0
+	github.com/moov-io/base v0.63.1
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	goftp.io/server/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/moov-io/base v0.63.0 h1:J2dGj5z5X2dbLumWkbCCjM6rWycf/Zfdvk31fHJQjZk=
 github.com/moov-io/base v0.63.0/go.mod h1:7lW1P0fiFOrINtS2zoxYtvTgvhdI0EcGSi5J//pIZcY=
 github.com/moov-io/base v0.63.1 h1:Jr/CYxfKugWv0WQmMno57ZUHnenAzHoHJ3stX0SWIMA=
 github.com/moov-io/base v0.63.1/go.mod h1:BYDXx00OEqPZMYQQdxf3x3zXdKCrm7FZvHoIArITjqc=
-github.com/moov-io/base v0.63.2 h1:ZbAr8StvwRphZ46El15bTbnJmDHZcArjOqy/0aqNllU=
-github.com/moov-io/base v0.63.2/go.mod h1:MEqa+7MXLHb1EacH3HZlcirgB8TxLalKvu7j+M7BXok=
 github.com/moov-io/iso3166 v0.4.0 h1:WtXIptANC16DrHpbSAt4+itFciCCnA+C6eAi9k7HEsA=
 github.com/moov-io/iso3166 v0.4.0/go.mod h1:13ubAoOZNfWzs2fN3x467zg8q982U867Ee+ulqrArlM=
 github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE=
@@ -111,8 +109,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
-github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Summary
- Adds a thin caller that runs [zizmor](https://docs.zizmor.sh) on every push and pull request.
- The job lives in [`moov-io/.github`](https://github.com/moov-io/.github/blob/master/.github/workflows/zizmor.yml) so the action version is shared across the org.

Findings are uploaded to **Security → Code scanning** and do not fail CI. Existing workflow issues can be triaged there.

## Test plan
- [ ] Confirm the `zizmor` workflow runs on this PR
- [ ] Confirm results appear under Security → Code scanning