### PR TITLE
fix: jail entries and batches search path to the FTP root

### DIFF
--- a/pkg/batches/repository_batch.go
+++ b/pkg/batches/repository_batch.go
@@ -74,9 +74,9 @@ func (r *batchRepository) Search(ctx context.Context, opts SearchOptions) ([]ach
 		attribute.Int("search.files_processed", filesProcessed),
 	)
 
-	var walkingPath = r.rootPath
-	if opts.Path != "" {
-		walkingPath = filepath.Join(r.rootPath, opts.Path)
+	walkingPath, err := service.ResolveWalkPath(r.rootPath, opts.Path)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := filepath.WalkDir(walkingPath, search); err != nil {

--- a/pkg/batches/repository_batch_test.go
+++ b/pkg/batches/repository_batch_test.go
@@ -52,6 +52,12 @@ func TestRepository(t *testing.T) {
 	// expect to get batches from outbound/1.ach
 	require.NoError(t, err)
 	require.Len(t, batches, 1)
+
+	_, err = repo.Search(ctx, SearchOptions{Path: ".."})
+	require.EqualError(t, err, "invalid path")
+
+	_, err = repo.Search(ctx, SearchOptions{Path: "/etc"})
+	require.EqualError(t, err, "invalid path")
 }
 
 func TestRepository__filterBatches(t *testing.T) {

--- a/pkg/entries/repository_entry.go
+++ b/pkg/entries/repository_entry.go
@@ -74,9 +74,9 @@ func (r *ftpRepository) Search(ctx context.Context, opts SearchOptions) ([]*ach.
 		attribute.Int("search.files_processed", filesProcessed),
 	)
 
-	var walkingPath = r.rootPath
-	if opts.Path != "" {
-		walkingPath = filepath.Join(r.rootPath, opts.Path)
+	walkingPath, err := service.ResolveWalkPath(r.rootPath, opts.Path)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := filepath.WalkDir(walkingPath, search); err != nil {

--- a/pkg/entries/repository_entry_test.go
+++ b/pkg/entries/repository_entry_test.go
@@ -52,6 +52,12 @@ func TestRepository(t *testing.T) {
 	// expect to get entries from outbound/1.ach
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
+
+	_, err = repo.Search(ctx, SearchOptions{Path: ".."})
+	require.EqualError(t, err, "invalid path")
+
+	_, err = repo.Search(ctx, SearchOptions{Path: "/etc"})
+	require.EqualError(t, err, "invalid path")
 }
 
 func TestRepository__filterEntries(t *testing.T) {

--- a/pkg/service/walkpath.go
+++ b/pkg/service/walkpath.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+var errInvalidPath = errors.New("invalid path")
+
+// ResolveWalkPath joins path onto root and rejects values that leave root.
+// filepath.Join treats an absolute element as a new root, so "/etc" would
+// otherwise walk the host filesystem instead of the FTP tree.
+func ResolveWalkPath(root, path string) (string, error) {
+	if path == "" {
+		return root, nil
+	}
+	if filepath.IsAbs(path) || strings.Contains(path, "..") {
+		return "", errInvalidPath
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	joined, err := filepath.Abs(filepath.Join(absRoot, path))
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(absRoot, joined)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errInvalidPath
+	}
+	return joined, nil
+}

--- a/pkg/service/walkpath_test.go
+++ b/pkg/service/walkpath_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveWalkPath(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := ResolveWalkPath(root, "")
+	require.NoError(t, err)
+	require.Equal(t, root, got)
+
+	got, err = ResolveWalkPath(root, "outbound")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(root, "outbound"), got)
+
+	_, err = ResolveWalkPath(root, "..")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = ResolveWalkPath(root, "../outbound")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = ResolveWalkPath(root, "/etc")
+	require.EqualError(t, err, "invalid path")
+}


### PR DESCRIPTION
# Changes

`GET /entries?path=` and `GET /batches?path=` joined the query onto `RootPath` then `WalkDir`'d it. `filepath.Join` treats an absolute element as a new root, so `path=/etc` walks `/etc` and `path=..` walks the parent. Shared `ResolveWalkPath` rejects `..` and absolute values, then requires the resolved path to stay under the FTP root.

`path=outbound` still returns the fixture entries. `path=..` and `path=/etc` return `invalid path`.

@adamdecaf

# Why Are Changes Being Made

Anyone who can GET the admin API already chooses `path`. They do not already have read outside `RootPath`. The remaining guard is that search stays under the FTP tree. Default admin binds `:3333` with no auth.

`TestRepository` (entries and batches) and `TestResolveWalkPath` fail if the jail is removed (`path=..` walks the parent) and pass with it.